### PR TITLE
Quick fix for macOS feedparser

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -1,0 +1,88 @@
+on:
+  push:
+    branches: [ dev ]
+
+name: Create Binaries dev
+jobs:
+  build:
+    name: Test on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ macOS-latest ]
+        include:
+          - os: ubuntu-latest
+            name: Ubuntu
+          - os: windows-latest
+            name: Windows
+          - os: macOS-latest
+            name: macOS
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Install Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+          cache: 'pip' # caching pip dependencies
+      - name: Install requirements
+        run: pip install -r requirements.txt PyInstaller
+      - name: Test python
+        run: python main.py -v -d searches_test -t 0 -f
+      - name: Run PyInstaller
+        run: pyinstaller --onefile -n arXiv-sorter-${{ matrix.name }} main.py
+      - name: Test binaries
+        run: dist/arXiv-sorter-${{ matrix.name }} -v -d ../searches_test -t 0 -f
+      - name: Upload binaries
+        uses: actions/upload-artifact@v3
+        with:
+          name: arXiv-sorter-${{ matrix.name }}
+          path: dist/
+
+  create_release:
+    needs: [ build ]
+    name: Create release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Install Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+          cache: 'pip' # caching pip dependencies
+      - name: Load binaries
+        uses: actions/download-artifact@v3
+
+      - name: Show files
+        run: ls -laRh
+
+      - name: Test python
+        run: |
+          filename=$(ls arXiv-sorter-Ubuntu/abstracts/)
+          fileA=arXiv-sorter-Ubuntu/abstracts/$filename
+          fileB=arXiv-sorter-Windows/abstracts/$filename
+          fileC=arXiv-sorter-macOS/abstracts/$filename
+          python tests/same_files.py $fileA $fileB $fileC
+
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          release_name: New release
+          draft: true
+          prerelease: false
+          tag_name: v0.0.0
+      - name: Upload Release Assets
+        uses: shogo82148/actions-upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./*/arXiv-sorter-*

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -11,10 +11,6 @@ jobs:
       matrix:
         os: [ macOS-latest ]
         include:
-          - os: ubuntu-latest
-            name: Ubuntu
-          - os: windows-latest
-            name: Windows
           - os: macOS-latest
             name: macOS
     steps:

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -9,8 +9,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ macOS-latest ]
+        os: [ ubuntu-latest, windows-latest, macOS-latest ]
         include:
+          - os: ubuntu-latest
+            name: Ubuntu
+          - os: windows-latest
+            name: Windows
           - os: macOS-latest
             name: macOS
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,13 +61,6 @@ jobs:
       - name: Show files
         run: ls -laRh
 
-      #      - name: Differences
-      #        run: |
-      #          filename=$(ls arXiv-sorter-Ubuntu/abstracts/)
-      #          echo $filename
-      #          cmp arXiv-sorter-Ubuntu/abstracts/2023-11-01.md arXiv-sorter-Windows/abstracts/2023-11-01.md
-      #          diff1=$(cmp arXiv-sorter-Ubuntu/abstracts/2023-11-01.md arXiv-sorter-Windows/abstracts/2023-11-01.md)
-      #          echo $diff1
       - name: Test python
         run: |
           filename=$(ls arXiv-sorter-Ubuntu/abstracts/)

--- a/arXiv_api.py
+++ b/arXiv_api.py
@@ -3,6 +3,7 @@ from datetime import datetime, timedelta
 from typing import List, Tuple
 
 import feedparser
+import requests
 
 from dates_functions import daterange, obtain_date
 
@@ -58,7 +59,10 @@ def search_entries(categories: List[str], date_0: datetime, date_f: datetime, _v
         entries = parse.entries  # Get entries
 
         if _verbose:
-            print(f'The response feed: {parse.feed}')
+            response = requests.get(base_url + query + n_entries + sort)
+            response = feedparser.parse(response.text)
+            print(f'The response (with request) is: {response.feed}')
+            print(f'The response (with feedparser) is: {parse.feed}')
             print(
                 f'The request is: {base_url + query + n_entries + sort}, and the number of entries is: {len(entries)}')
 

--- a/arXiv_api.py
+++ b/arXiv_api.py
@@ -1,7 +1,8 @@
-import feedparser
 import time
-from typing import List, Tuple
 from datetime import datetime, timedelta
+from typing import List, Tuple
+
+import feedparser
 
 from dates_functions import daterange, obtain_date
 
@@ -53,8 +54,11 @@ def search_entries(categories: List[str], date_0: datetime, date_f: datetime, _v
             time.sleep(t_sleep - elapsed_time)
 
         t_previous_request = time.time()
-        entries = feedparser.parse(base_url + query + n_entries + sort).entries  # Get entries
+        parse = feedparser.parse(base_url + query + n_entries + sort)  # Ask for entries
+        entries = parse.entries  # Get entries
+
         if _verbose:
+            print(f'The response feed: {parse.feed}')
             print(
                 f'The request is: {base_url + query + n_entries + sort}, and the number of entries is: {len(entries)}')
 

--- a/arXiv_api.py
+++ b/arXiv_api.py
@@ -55,16 +55,15 @@ def search_entries(categories: List[str], date_0: datetime, date_f: datetime, _v
             time.sleep(t_sleep - elapsed_time)
 
         t_previous_request = time.time()
-        parse = feedparser.parse(base_url + query + n_entries + sort)  # Ask for entries
-        entries = parse.entries  # Get entries
+
+        # Do not know why, but it is necessary for Mac to use requests, and then feedparser
+        response = requests.get(base_url + query + n_entries + sort)
+        response = feedparser.parse(response)  # Ask for entries
+        entries = response.entries  # Get entries
 
         if _verbose:
-            response = requests.get(base_url + query + n_entries + sort)
             response = feedparser.parse(response.text)
-            print(f'The response (with request) is: {response.feed}')
-            print(f'The response (with feedparser) is: {parse.feed}')
-            print(
-                f'The request is: {base_url + query + n_entries + sort}, and the number of entries is: {len(entries)}')
+            print(f'The response feed is: {response.feed}')
 
         total_entries += entries
         if len(entries) == 0 or len(entries) < n_max:  # If there are no more entries, stop

--- a/arXiv_api.py
+++ b/arXiv_api.py
@@ -58,19 +58,15 @@ def search_entries(categories: List[str], date_0: datetime, date_f: datetime, _v
 
         # Do not know why, but it is necessary for Mac to use requests, and then feedparser
         response = requests.get(base_url + query + n_entries + sort)
-        response = feedparser.parse(response)  # Ask for entries
+        response = feedparser.parse(response.text)  # Ask for entries
         entries = response.entries  # Get entries
 
         if _verbose:
-            response = feedparser.parse(response.text)
-            print(f'The response feed is: {response.feed}')
+            print(f'The response feed is: {response.feed} \n')
 
         total_entries += entries
         if len(entries) == 0 or len(entries) < n_max:  # If there are no more entries, stop
             break
-
-    if _verbose:
-        print(f'Found {len(total_entries)} entries between {date_0.date()} and {date_f.date()}')
 
     return _sort_entries(total_entries, date_0, date_f)
 

--- a/main.py
+++ b/main.py
@@ -40,7 +40,7 @@ if not os.path.isdir(keyword_dir):
     os.mkdir(keyword_dir)  # Create dir if it doesn't exist
 
 if verbose:
-    print(f'The current dir is: {os.getcwd()}, and the keywords dir is: {keyword_dir}')
+    print(f'The current dir is: {os.getcwd()}, and the keywords dir is: {keyword_dir} \n')
 
 # Read user files
 keywords = read_user_file(keyword_dir + 'keywords.txt')

--- a/main.py
+++ b/main.py
@@ -11,7 +11,7 @@ from read_files import read_user_file
 from sort_entries import sort_articles
 from update import check_version
 
-version = '0.0.6'
+version = '0.0.7'
 
 parser = argparse.ArgumentParser()
 parser.add_argument('-v', '--verbose', action='store_true', help='increase output verbosity')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 feedparser
 unidecode
 requests
+packaging

--- a/update.py
+++ b/update.py
@@ -56,7 +56,7 @@ def check_version(previous_version: str, _verbose: bool = False):
 
     if _verbose:
         print('The GitHub response for the latest release is:')
-        print(response.json())
+        print(response.json(), '\n')
 
     new_version = response.json()['tag_name']
 

--- a/update.py
+++ b/update.py
@@ -2,9 +2,10 @@ import os
 import sys
 from platform import system
 from subprocess import Popen
-from packaging import version
+from time import sleep
 
 import requests
+from packaging import version
 
 URL = 'https://api.github.com/repos/Davtax/arXiv-sorter/releases/latest'
 
@@ -43,7 +44,14 @@ def check_version(previous_version: str, _verbose: bool = False):
     """
     Check in GitHub if there is a new version available. If so, download and execute it.
     """
-    response = requests.get(URL)
+    while True:
+        response = requests.get(URL)
+        if response.status_code == 200:
+            break
+        elif response.status_code == 403 or response.status_code == 429:
+            print('Too many requests to GitHub, waiting 30 seconds')
+            sleep(30)
+
     platform = get_system_name()
 
     if _verbose:

--- a/update.py
+++ b/update.py
@@ -2,6 +2,7 @@ import os
 import sys
 from platform import system
 from subprocess import Popen
+from packaging import version
 
 import requests
 
@@ -51,7 +52,7 @@ def check_version(previous_version: str, _verbose: bool = False):
 
     new_version = response.json()['tag_name']
 
-    if previous_version < new_version:
+    if version.parse(previous_version) < version.parse(new_version):
         print('New version available: ' + new_version)
 
         if '.py' not in sys.argv[0] and question('Do you want to update arXiv-sorter?'):


### PR DESCRIPTION
When the binaries for macOS are built from GitHub actions, the `feedparser` package does not correctly get responses from the arXiv API (maybe due to differences from Intel and M2?). This error is solved by getting the response from arXiv using the `request` package, and formating the text with `feedparser`.