### PR TITLE
Use temporal folders for donwload the pdfs and search for figures

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,14 +148,6 @@ The process of downloading the .PDF file, detecting and extracting the figure is
 so it is only done for new manuscripts, and those new versions of the manuscripts that contain the keywords.
 However, it can be entirely disabled with the `--image` flag (see below).
 
-> [!NOTE]  
-> Because, reasons, Obsidian does not recognize relative paths for images.
-> To surpass this, you have to manually download the files: [main.js](https://github.com/csdjk/lcl-obsidian-html-local-img-plugin/releases/download/1.0.0/main.js)
-> and [manifest.json](https://github.com/csdjk/lcl-obsidian-html-local-img-plugin/releases/download/1.0.0/manifest.json).
-> After that, create the folder `.obsidian/plugins/lcl-obsidian-html-local-img-plugin` in your vault directory, and place the files there.
-> Finally, enable the plugin in the Obsidian/Settings/Community plugins.
-> If you have never used Community plugins before, you have to enable them before.
-
 > [!WARNING]  
 > The program will download the .PDF files directly from the arXiv website.
 > There is a waiting time between each download to avoid being blocked by the arXiv server.
@@ -173,8 +165,6 @@ When running the program from the terminal, you can use the following optional a
   The default value is the current directory (`./`).
 - `--abstracts` or `-a`: Specify the directory where the abstracts are located.
   The default value is the `abstracts` folder in the current directory (`/abstracts`).
-- `--time` or `-t`: Specify the terminal closing time in seconds.
-  The default value is 3 seconds.
 - `--final` or `-f`: Remove the final time stamp from the markdown file.
 - `--update` or `-u`: Check if there is a new version of the program available in GitHub, and update the program if
   true.

--- a/app/format_entries.py
+++ b/app/format_entries.py
@@ -167,7 +167,7 @@ def _write_document_join(file_name: str, entries: List[FeedParserDict], image_ur
 
     with open(file_name, 'w', encoding='utf-8') as f:
         [write_article(entries[index], f, index, n_new, image_url=image_urls[index]) for index in
-         range(n_new)]  # Write new article (or with new keyword)
+         range(n_new)]  # Write a new article (or with a new keyword)
 
         [write_article(entries[index], f, index - n_new, n_total - n_new) for index in
          range(n_new, n_total)]  # Write updated articles

--- a/run.py
+++ b/run.py
@@ -1,4 +1,14 @@
 from app.main import main
+import tempfile
+
+temp_dir = tempfile.TemporaryDirectory()
 
 if __name__ == '__main__':
-    main()
+    try:  # Catch potential errors
+        main(temp_dir)
+    except Exception as e:
+        print(f'An error occurred: {e}')
+
+    temp_dir.cleanup()
+
+    input('Press Enter to exit...')


### PR DESCRIPTION
This pull request introduces several updates to improve code clarity, remove unused features, and enhance the handling of temporary directories and folder structures. The changes also include updates to the README documentation for better user guidance. Below is a summary of the most important changes:

### Documentation Updates:
* Removed outdated instructions related to manually downloading plugin files and enabling community plugins in Obsidian from the `README.md` file.
* Removed the `--time` flag from the list of optional command-line arguments in the `README.md` file, as it is no longer supported.

### Code Cleanup and Refactoring:
* Removed the unused `timing_message` import and the `clean_up` function from `app/main.py`, simplifying the code. [[1]](diffhunk://#diff-990f7e4140fab1ad82afc787505090b64d4024e63a891405cd9085e7e6b249ddL15-R15) [[2]](diffhunk://#diff-990f7e4140fab1ad82afc787505090b64d4024e63a891405cd9085e7e6b249ddL168-L170)
* Renamed `TMP_FOLDER` to `ARXIV_SORTER_FOLDER` in `app/main.py` and `TMP_FOLDER` to `FIGURES_FOLDER` in `app/pdf_scrapper.py` for better clarity and consistency. [[1]](diffhunk://#diff-990f7e4140fab1ad82afc787505090b64d4024e63a891405cd9085e7e6b249ddL69-R64) [[2]](diffhunk://#diff-5c8646da97e08bfc2563845151b79e7fe0fb73ceb81e293d597a13b40cbb2295L17-R17)

### Temporary Directory Management:
* Introduced the use of Python's `tempfile.TemporaryDirectory` in `run.py` to manage temporary directories more robustly and ensure cleanup after execution.
* Updated `get_images_pdf_scrapper` in `app/pdf_scrapper.py` to accept a temporary directory as an argument, improving flexibility and encapsulation. [[1]](diffhunk://#diff-5c8646da97e08bfc2563845151b79e7fe0fb73ceb81e293d597a13b40cbb2295L148-R167) [[2]](diffhunk://#diff-990f7e4140fab1ad82afc787505090b64d4024e63a891405cd9085e7e6b249ddL157-R149)

### Minor Fixes and Improvements:
* Corrected a typo in a comment in `app/format_entries.py` ("Write new article" to "Write a new article").
* Replaced the deprecated `activeCount` method with `active_count` from the `threading` module in `app/pdf_scrapper.py`.

### Version Update:
* Incremented the version number from `0.2.3` to `0.2.4` in `app/main.py` to reflect the changes.